### PR TITLE
Use req file install

### DIFF
--- a/aliveApp/Db/Makefile
+++ b/aliveApp/Db/Makefile
@@ -13,6 +13,7 @@ include $(TOP)/configure/CONFIG
 DB += alive.db
 DB += aliveMSGCalc.db
 
+REQ += aliveMSGCalc_local.req
 #----------------------------------------------------
 # If <anyname>.db template is not named <anyname>*.template add
 # <anyname>_TEMPLATE = <templatename>

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -21,8 +21,10 @@
 
 TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
 
+SUPPORT=
+
 # EPICS_BASE usually appears last so other apps can override stuff:
-EPICS_BASE=/APSshare/epics/base-3.14.12.5
+EPICS_BASE=/APSshare/epics/base-3.15.5
 -include $(TOP)/../configure/EPICS_BASE.$(EPICS_HOST_ARCH)
 
 # Set RULES here if you want to take build rules from somewhere


### PR DESCRIPTION
SynApps modules can now install req files to the top-level db folder. This updates alive to take advantage of that feature.